### PR TITLE
Fix use of deprecation warning in se2lib property

### DIFF
--- a/PageObjectLibrary/pageobject.py
+++ b/PageObjectLibrary/pageobject.py
@@ -63,7 +63,7 @@ class PageObject(six.with_metaclass(ABCMeta, object)):
     # test (eg: by libdoc, robotframework-hub, etc)
     @property
     def se2lib(self):
-        warnings.warn("se2lib is deprecated. Use selib intead.", warnings.DeprecationWarning)
+        warnings.warn("se2lib is deprecated. Use selib intead.", DeprecationWarning)
         return self.selib
 
     @property


### PR DESCRIPTION
DeprecationWarning is a builtin exception and is not part of the warnings module