### PR TITLE
Add support for multiple hosts

### DIFF
--- a/PageObjectLibrary/keywords.py
+++ b/PageObjectLibrary/keywords.py
@@ -94,6 +94,8 @@ class PageObjectLibraryKeywords(object):
 
         url = page_root if page_root is not None else page.selib.get_location()
         (scheme, netloc, path, parameters, query, fragment) = urlparse(url)
+        if hasattr(page, 'PAGE_HOST'):
+            netloc = page.PAGE_HOST
         url = "%s://%s%s" % (scheme, netloc, page.PAGE_URL)
 
         with page._wait_for_page_refresh():


### PR DESCRIPTION
Currently this library only allows pages to be registered for one host,
by adding a `PAGE_HOST` attribute to the page object we can now have page objects for different hosts.